### PR TITLE
Use Curb instead of Net::HTTP

### DIFF
--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -89,7 +89,7 @@ module Sinatra
         res, body = http.post("/verify", data_str)
 
         # TODO: check res is a 200
-        verify = JSON.parse(body) || nil
+        verify = JSON.parse(body) || nil rescue nil # Not sure why JSON parsing can fail with a nil value in 1.9.3
         if verify.nil?
           # JSON parsing error
           return

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -88,9 +88,11 @@ module Sinatra
         data_str = data.collect { |k, v| "#{k}=#{v}" }.join("&")
         res, body = http.post("/verify", data_str)
 
+        # hack
+        body ||= %({"status":"okay","email":"nobody@here","expires":"3600000"}) if res.is_a?(Net::HTTPSuccess)
         # TODO: check res is a 200
-        verify = JSON.parse(body) || nil rescue nil # Not sure why JSON parsing can fail with a nil value in 1.9.3
-        if verify.nil?
+        verify = JSON.parse(body) || nil
+        if !res.is_a?(Net::HTTPSuccess) || verify.nil?
           # JSON parsing error
           return
         end

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "json"
-require "net/https"
+require 'curb'
 require "sinatra/base"
 
 # This module provides an interface to verify a users email address
@@ -77,23 +77,28 @@ module Sinatra
 
       app.post '/_browserid_assert' do
         # TODO(petef): do verification locally, without a callback
-        audience = request.host_with_port
-        bid_uri = URI.parse(settings.browserid_url)
-        http = Net::HTTP.new(bid_uri.host, bid_uri.port)
-        http.use_ssl = true
         data = {
           "assertion" => params[:assertion],
-          "audience" => audience,
+          "audience" => request.host_with_port,
         }
         data_str = data.collect { |k, v| "#{k}=#{v}" }.join("&")
-        res, body = http.post("/verify", data_str)
+        body = ""
+        c = begin
+          Curl::Easy.http_post(settings.browserid_url + "/verify") do |curl|
+            curl.use_ssl = Curl::CURL_USESSL_ALL
+            curl.post_body = data_str
+            curl.on_body {|data| body << data; data.length}
+          end
+        rescue Exception => e
+          # Processing error
+          $stderr.puts "request was not successful. #{e.message}"
+          return
+        end
 
-        # hack
-        body ||= %({"status":"okay","email":"nobody@here","expires":"3600000"}) if res.is_a?(Net::HTTPSuccess)
-        # TODO: check res is a 200
         verify = JSON.parse(body) || nil
-        if !res.is_a?(Net::HTTPSuccess) || verify.nil?
+        if verify.nil?
           # JSON parsing error
+          $stderr.puts "Invalid Response"
           return
         end
 

--- a/sinatra-browserid.gemspec
+++ b/sinatra-browserid.gemspec
@@ -13,4 +13,5 @@ Gem::Specification.new do |s|
   s.summary = "Sinatra extension for user authentication with browserid.org"
 
   s.add_dependency("sinatra", ">= 1.1.0")
+  s.add_dependency("curb", ">= 0.8.0")
 end


### PR DESCRIPTION
This deals with the problem in 1.9.3 with Net::HTTP returning null, as indicated in issue #1. Curb uses libcurl.
