### PR TITLE
Fix empty body in browserid assert

### DIFF
--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -88,10 +88,9 @@ module Sinatra
         data_str = data.collect { |k, v| "#{k}=#{v}" }.join("&")
         res = http.post("/verify", data_str)
 
-        # TODO: check res is a 200
-        verify = JSON.parse(res.body) || nil
-        if verify.nil?
-          # JSON parsing error
+        if res.code =~ /^2\d{2}$/
+          verify = ::JSON.parse(res.body)
+        else
           return
         end
 

--- a/lib/sinatra/browserid.rb
+++ b/lib/sinatra/browserid.rb
@@ -86,10 +86,10 @@ module Sinatra
           "audience" => audience,
         }
         data_str = data.collect { |k, v| "#{k}=#{v}" }.join("&")
-        res, body = http.post("/verify", data_str)
+        res = http.post("/verify", data_str)
 
         # TODO: check res is a 200
-        verify = JSON.parse(body) || nil
+        verify = JSON.parse(res.body) || nil
         if verify.nil?
           # JSON parsing error
           return


### PR DESCRIPTION
fixes #1
also makes sure the correct `JSON` class is picked up which is an issue if there is an `Sinatra::JSON` module (`sinatra-contrib` provides that for example)

As Bonus it adds a simple check on the response code and only accepts codes in the 2xx range.
